### PR TITLE
Added function to compare error

### DIFF
--- a/testing/error.go
+++ b/testing/error.go
@@ -1,23 +1,15 @@
 package testing
 
 func IsErrorEqual(a, b error) bool {
-	isANil := a == nil
-	isBNil := b == nil
-
 	// If both are nil then true
-	if isANil && isBNil {
+	if a == nil && b == nil {
 		return true
 	}
 
 	// If either one in nil then false
-	if isANil || isBNil {
+	if a == nil || b == nil {
 		return false
 	}
 
-	// If error message differ than true
-	if a.Error() != b.Error() {
-		return false
-	}
-
-	return true
+	return a.Error() == b.Error()
 }

--- a/testing/error.go
+++ b/testing/error.go
@@ -1,0 +1,23 @@
+package testing
+
+func IsErrorEqual(a, b error) bool {
+	isANil := a == nil
+	isBNil := b == nil
+
+	// If both are nil then true
+	if isANil && isBNil {
+		return true
+	}
+
+	// If either one in nil then false
+	if isANil || isBNil {
+		return false
+	}
+
+	// If error message differ than true
+	if a.Error() != b.Error() {
+		return false
+	}
+
+	return true
+}

--- a/testing/error.go
+++ b/testing/error.go
@@ -1,15 +1,18 @@
 package testing
 
-func IsErrorEqual(a, b error) bool {
+/**
+	Compare the given errors and return true if equal, or else returns false.
+**/
+func IsErrorEqual(wantErr, err error) bool {
 	// If both are nil then true
-	if a == nil && b == nil {
+	if wantErr == nil && err == nil {
 		return true
 	}
 
 	// If either one in nil then false
-	if a == nil || b == nil {
+	if wantErr == nil || err == nil {
 		return false
 	}
 
-	return a.Error() == b.Error()
+	return wantErr.Error() == err.Error()
 }

--- a/testing/error_test.go
+++ b/testing/error_test.go
@@ -1,0 +1,53 @@
+package testing
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsErrorEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    error
+		b    error
+		want bool
+	}{
+		{
+			name: "Both nil",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "Error a nil",
+			a:    nil,
+			b:    fmt.Errorf("Error"),
+			want: false,
+		},
+		{
+			name: "Error b Nil",
+			a:    fmt.Errorf("Error"),
+			b:    nil,
+			want: false,
+		},
+		{
+			name: "Both different error",
+			a:    fmt.Errorf("Error 1"),
+			b:    fmt.Errorf("Error 2"),
+			want: false,
+		},
+		{
+			name: "Same error",
+			a:    fmt.Errorf("Error"),
+			b:    fmt.Errorf("Error"),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsErrorEqual(tt.a, tt.b); got != tt.want {
+				t.Errorf("IsErrorDiff() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/testing/error_test.go
+++ b/testing/error_test.go
@@ -7,39 +7,39 @@ import (
 
 func TestIsErrorEqual(t *testing.T) {
 	tests := []struct {
-		a    error
-		b    error
-		want bool
+		wantErr error
+		err     error
+		want    bool
 	}{
 		{
-			a:    nil,
-			b:    nil,
-			want: true,
+			wantErr: nil,
+			err:     nil,
+			want:    true,
 		},
 		{
-			a:    nil,
-			b:    fmt.Errorf("Error"),
-			want: false,
+			wantErr: nil,
+			err:     fmt.Errorf("Error"),
+			want:    false,
 		},
 		{
-			a:    fmt.Errorf("Error"),
-			b:    nil,
-			want: false,
+			wantErr: fmt.Errorf("Error"),
+			err:     nil,
+			want:    false,
 		},
 		{
-			a:    fmt.Errorf("Error 1"),
-			b:    fmt.Errorf("Error 2"),
-			want: false,
+			wantErr: fmt.Errorf("Error 1"),
+			err:     fmt.Errorf("Error 2"),
+			want:    false,
 		},
 		{
-			a:    fmt.Errorf("Error"),
-			b:    fmt.Errorf("Error"),
-			want: true,
+			wantErr: fmt.Errorf("Error"),
+			err:     fmt.Errorf("Error"),
+			want:    true,
 		},
 	}
 	for _, input := range tests {
-		t.Run("IsErrorEqual", func(t *testing.T) {
-			if got := IsErrorEqual(input.a, input.b); got != input.want {
+		t.Run(fmt.Sprintf("IsErrorEqual(%v, %v)", input.wantErr, input.err), func(t *testing.T) {
+			if got := IsErrorEqual(input.wantErr, input.err); got != input.want {
 				t.Errorf("IsErrorEqual() = %v, want %v", got, input.want)
 			}
 		})

--- a/testing/error_test.go
+++ b/testing/error_test.go
@@ -7,46 +7,40 @@ import (
 
 func TestIsErrorEqual(t *testing.T) {
 	tests := []struct {
-		name string
 		a    error
 		b    error
 		want bool
 	}{
 		{
-			name: "Both nil",
 			a:    nil,
 			b:    nil,
 			want: true,
 		},
 		{
-			name: "Error a nil",
 			a:    nil,
 			b:    fmt.Errorf("Error"),
 			want: false,
 		},
 		{
-			name: "Error b Nil",
 			a:    fmt.Errorf("Error"),
 			b:    nil,
 			want: false,
 		},
 		{
-			name: "Both different error",
 			a:    fmt.Errorf("Error 1"),
 			b:    fmt.Errorf("Error 2"),
 			want: false,
 		},
 		{
-			name: "Same error",
 			a:    fmt.Errorf("Error"),
 			b:    fmt.Errorf("Error"),
 			want: true,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := IsErrorEqual(tt.a, tt.b); got != tt.want {
-				t.Errorf("IsErrorDiff() = %v, want %v", got, tt.want)
+	for _, input := range tests {
+		t.Run("IsErrorEqual", func(t *testing.T) {
+			if got := IsErrorEqual(input.a, input.b); got != input.want {
+				t.Errorf("IsErrorEqual() = %v, want %v", got, input.want)
 			}
 		})
 	}


### PR DESCRIPTION
**- What is this change?**
  Added function to compare error and decide if error are equal or not.

**- Why are we doing?**
  Because it is a common requirement while unit testing in go and requires to right lengthy if else statements each time.
  Eg: `if (tt.wantErr != nil && err != nil && tt.wantErr.Error() != err.Error()) || ((tt.wantErr != nil) != (err != nil))`

**- How was it done before?**
  By manually handling it through writing repetitive if else statement to compare error. 

**- Impact (how efficient is the new flow now)**
  Their will be no need to write those if else manually and a single function call will do the job.